### PR TITLE
fix broken link / typo in readme document

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Contributing
 
-Read the [contributing guide](./blob/mb-pages/CONTRIBUTING.md) to learn how to add or edit any content.
+Read the [contributing guide](./blob/gh-pages/CONTRIBUTING.md) to learn how to add or edit any content.
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Contributing
 
-Read the [contributing guide](./blob/gh-pages/CONTRIBUTING.md) to learn how to add or edit any content.
+Read the [contributing guide](CONTRIBUTING.md) to learn how to add or edit any content.
 
 ## Build
 


### PR DESCRIPTION
Currently, the link in the readme document points to a non-existant branch/page. This fixes it by linking to correct contributing markdown document.