### PR TITLE
change header subtitle wording

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -81,7 +81,7 @@
     </a>
     <div class="fl">
     <h1 class="human">{{page.title}}</h1>
-    <p class="quiet space-top0">With an organization making plans for OSM? Find what you need to know!</p>
+    <p class="quiet space-top0">Does your organization want to work with OSM? Find what you need to know!</p>
     </div>
   </div>
   <div class="fr">


### PR DESCRIPTION
from the `osmf-talk` listserve

> "Does your organisation want to work with OSM?" may be better than the current "With an organization making plans for OSM?" It took me several attempts to understand the current strapline.

> I see a banner Welcome Mat I OpenStreetMap followed by With an organisation making plans for OSM... My question is What organisation? As a new member I would think that means Welcome Mat is an organisatiopn making plans for OSM. Which makes no sense. 

reading it with my version of "American English" i also found the current phrasing awkward

one comment from the list was to include the following instead:
> A warm welcome to our new members and thank you for your interest in the advancement and improvement of OpenStreetMap.
On this page you will find links to explain what we are about and to the various aspects and activities that this community is involved in and hopefully you will be able to find an activity that is suited to your special skill sets. There are also links to training materials and Mapathons to help you to learn new skill sets so that you can expand your contribution to OpenStreetMap and be involved in new ventures.

but that's a bit much for a subtitle 😉  

other ideas on the wording change welcome. "Are you with an organization making plans for OSM?" or "Is your organization making plans for OSM?" or "Does your organization have questions about OSM?" might stay closer to the current wording while helping read more clearly.