### PR TITLE
update readme to remove the baseurl for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This site is built with [Jekyll](https://help.github.com/articles/setting-up-you
 
 **Running site locally**
 
-    jekyll serve
+    jekyll serve -b ''
 
 **Testing site** (if testing for the first time, run `npm install` first);
 


### PR DESCRIPTION
running "jekyll serve" locally tries to run the server at
`
Server address: http://127.0.0.1:4000https://welcome.openstreetmap.org/
`

This PR updates the readme to effectively null the baseurl specified in the _config.yml file. 

(I imagine we could review whether https://welcome.openstreetmap.org/  is required in _config.yml but I thought there were probably Reasons. )