### PR TITLE
Fix liquid syntax error

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -12,7 +12,7 @@ options: full
 
   {% include search.html %}
 
-  {% assign pages = (site.pages | where: "layout", "category" | where: "lang", lang | sort: "order") %}
+  {% assign pages = site.pages | where: "layout", "category" | where: "lang", lang | sort: "order" %}
   {% for page in pages %}
   <!-- build guideCount-->
   {% assign langDir = page.lang | append: '/' %}


### PR DESCRIPTION
Fixed liquid syntax error in `_layouts/home.html`
Liquid doesn't take parentheses.
"Closes: #47" 
 @mikelmaron review for merge. @mmd-osm amendment to #48