### PR TITLE
Show images from the homepage tiles at the beginning of the respective pages

### DIFF
--- a/overrides/partials/content.html
+++ b/overrides/partials/content.html
@@ -1,0 +1,64 @@
+<!--
+  Copyright (c) 2016-2025 Martin Donath <martin.donath@squidfunk.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+-->
+
+<!-- Tags -->
+{% include "partials/tags.html" %}
+
+<!-- Actions -->
+{% include "partials/actions.html" %}
+
+<!--
+  Hack: check whether the content contains a h1 headline. If it doesn't, the
+  page title (or respectively site name) is used as the main headline.
+-->
+{% if "\x3ch1" not in page.content %}
+<h1>{{ page.title | d(config.site_name, true)}}</h1>
+{% endif %}
+
+<!-- Page content -->
+<!--
+  The following code helps to display images from the homepage tiles at
+  the beginning of the respective pages, which makes it easier to navigate
+  and more attractive to the user.
+-->
+{% if page.meta and page.meta.tile and page.meta.tile.image %}
+  {% set image = page.meta.tile.image %}
+  {% set img_path = "/assets/images/"%}
+    <figure>
+      <img src="{{ img_path }}{{ image.src }}" alt="{{ image.alt }}">
+      {% if image.alt %}
+        <figcaption>{{ image.alt }}</figcaption>
+      {% endif %}
+    </figure>
+{% endif %}
+
+{{ page.content }}
+
+
+<!-- Source file information -->
+{% include "partials/source-file.html" %}
+
+<!-- Was this page helpful? -->
+{% include "partials/feedback.html" %}
+
+<!-- Comment system -->
+{% include "partials/comments.html" %}


### PR DESCRIPTION
The proposed code helps to display images from the home page tiles at the beginning of the corresponding pages. This makes visual navigation easier when the user sees the same image on the page as on the tile on the home page. It also adds some visual support to the text.

<img width="1348" height="1505" alt="image" src="https://github.com/user-attachments/assets/0470739f-bb32-45b5-844a-ae8460f845a6" />

Re Issue #27 