### PR TITLE
Fix Deutsche Bahn OSM consumer wiki image URL

### DIFF
--- a/docs/en/about-osm-community/consumers.md
+++ b/docs/en/about-osm-community/consumers.md
@@ -28,7 +28,7 @@ Here is a non-exhaustive list of some big organizations that use OpenStreetMap, 
 
 * [Air France](https://wiki.openstreetmap.org/wiki/File:Air_France_seatback_map_display.jpg){:target="_blank"}
 * [Alaska Airlines](https://twitter.com/openstreetmapes/status/554009623062388736){:target="_blank"}
-* [Deutsche Bahn](https://wiki.openstreetmap.org/wiki/File:OpenStreetMap_in_an_IC2_carriage_(DB){:target="_blank"}.jpg)
+* [Deutsche Bahn](https://wiki.openstreetmap.org/wiki/File:OpenStreetMap_in_an_IC2_carriage_(DB).jpg){:target="_blank"}
 * Grab
 * SNCF (French rail agency)
 * Uber

--- a/docs/it/about-osm-community/consumers.md
+++ b/docs/it/about-osm-community/consumers.md
@@ -28,7 +28,7 @@ Quella che segue è una lista incompleta delle grandi organizzazioni che usano O
 
 * [Air France](https://wiki.openstreetmap.org/wiki/File:Air_France_seatback_map_display.jpg){:target="_blank"}
 * [Alaska Airlines](https://twitter.com/openstreetmapes/status/554009623062388736){:target="_blank"}
-* [Deutsche Bahn](https://wiki.openstreetmap.org/wiki/File:OpenStreetMap_in_an_IC2_carriage_(DB){:target="_blank"}.jpg)
+* [Deutsche Bahn](https://wiki.openstreetmap.org/wiki/File:OpenStreetMap_in_an_IC2_carriage_(DB).jpg){:target="_blank"}
 * Grab
 * SNCF (French rail agency)
 * Uber

--- a/docs/ja/about-osm-community/consumers.md
+++ b/docs/ja/about-osm-community/consumers.md
@@ -28,7 +28,7 @@ lang: ja
 
 * [エールフランス航空](https://wiki.openstreetmap.org/wiki/File:Air_France_seatback_map_display.jpg){:target="_blank"}
 * [アラスカ航空](https://twitter.com/openstreetmapes/status/554009623062388736){:target="_blank"}
-* [ドイツ鉄道](https://wiki.openstreetmap.org/wiki/File:OpenStreetMap_in_an_IC2_carriage_(DB){:target="_blank"}.jpg)
+* [ドイツ鉄道](https://wiki.openstreetmap.org/wiki/File:OpenStreetMap_in_an_IC2_carriage_(DB).jpg){:target="_blank"}
 * Grab
 * SNCF(フランスの鉄道機関)
 * Uber

--- a/docs/pl/about-osm-community/consumers.md
+++ b/docs/pl/about-osm-community/consumers.md
@@ -28,7 +28,7 @@ Oto niewyczerpująca lista niektórych dużych organizacji korzystających z Pro
 
 * [Air France](https://wiki.openstreetmap.org/wiki/File:Air_France_seatback_map_display.jpg){:target="_blank"}
 * [Alaska Airlines](https://twitter.com/openstreetmapes/status/554009623062388736){:target="_blank"}
-* [Deutsche Bahn](https://wiki.openstreetmap.org/wiki/File:OpenStreetMap_in_an_IC2_carriage_(DB){:target="_blank"}.jpg)
+* [Deutsche Bahn](https://wiki.openstreetmap.org/wiki/File:OpenStreetMap_in_an_IC2_carriage_(DB).jpg){:target="_blank"}
 * Grab
 * SNCF (Francuska agencja kolejowa)
 * Uber

--- a/docs/ru/about-osm-community/consumers.md
+++ b/docs/ru/about-osm-community/consumers.md
@@ -28,7 +28,7 @@ lang: ru
 
 * [Air France](https://wiki.openstreetmap.org/wiki/File:Air_France_seatback_map_display.jpg){:target="_blank"}
 * [Alaska Airlines](https://twitter.com/openstreetmapes/status/554009623062388736){:target="_blank"}
-* [Deutsche Bahn](https://wiki.openstreetmap.org/wiki/File:OpenStreetMap_in_an_IC2_carriage_(DB){:target="_blank"}.jpg)
+* [Deutsche Bahn](https://wiki.openstreetmap.org/wiki/File:OpenStreetMap_in_an_IC2_carriage_(DB).jpg){:target="_blank"}
 * Grab
 * SNCF (французское железнодорожное агентство)
 * Uber

--- a/docs/uk/about-osm-community/consumers.md
+++ b/docs/uk/about-osm-community/consumers.md
@@ -28,7 +28,7 @@ lang: uk
 
 * [Air France](https://wiki.openstreetmap.org/wiki/File:Air_France_seatback_map_display.jpg){:target="_blank"}
 * [Alaska Airlines](https://twitter.com/openstreetmapes/status/554009623062388736){:target="_blank"}
-* [Deutsche Bahn](https://wiki.openstreetmap.org/wiki/File:OpenStreetMap_in_an_IC2_carriage_(DB){:target="_blank"}.jpg)
+* [Deutsche Bahn](https://wiki.openstreetmap.org/wiki/File:OpenStreetMap_in_an_IC2_carriage_(DB).jpg){:target="_blank"}
 * Grab
 * SNCF (Французька залізниця)
 * Uber


### PR DESCRIPTION
Fixed in all languages. bn and es already had the fixed version. 
