### PR TITLE
Fixing grammar error in history-of-osm.md (English version)

### DIFF
--- a/docs/en/about-osm-community/history-of-osm.md
+++ b/docs/en/about-osm-community/history-of-osm.md
@@ -12,6 +12,6 @@ tile:
 lang: en 
 ---
 
-[OpenStreetMap](https://openstreetmap.org){:target="_blank"} was founded in the UK in 2004 by Steve Coast, and taken up by a community of map enthusiasts who wanted a free and open source of data. It has since grown to more than 1 million contributors around the world: individual volunteers, map enthusiast, GIS and geography data specialists, companies that use map data, humanitarian organizations, government agencies and more.
+[OpenStreetMap](https://openstreetmap.org){:target="_blank"} was founded in the UK in 2004 by Steve Coast, and taken up by a community of map enthusiasts who wanted a free and open source of data. It has since grown to more than 1 million contributors around the world: individual volunteers, map enthusiasts, GIS and geography data specialists, companies that use map data, humanitarian organizations, government agencies and more.
 
 In 2006, the [OpenStreetMap Foundation](/about-osm-community/osm-foundation.md) was established to encourage the growth, development and distribution of free geospatial data and provide geospatial data for anybody to use and share. In 2012, OpenStreetMap switched to licensing data under the [Open Database License](https://wiki.osmfoundation.org/wiki/Licence){:target="_blank"}.


### PR DESCRIPTION
Fixing a grammar error in the English version of history-of-osm.md (map enthusiast -> map enthusiast**s**).